### PR TITLE
Update japa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,8 @@ name: Bun CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
-name: Node.js CI
+name: Bun CI
 
 on:
   push:
@@ -17,19 +14,8 @@ jobs:
       JSB_PUBLIC_KEY: ${{ secrets.JSB_PUBLIC_KEY }}
       JSB_PRIVATE_KEY: ${{ secrets.JSB_PRIVATE_KEY }}
 
-    strategy:
-      matrix:
-        node-version: [ 18.x ]
-        #        node-version: [ 16.x, 18.x ]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      - run: bun test
+      - run: bun run test

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ node_modules
 tests/.env
 
 *.js
-!japaFile.js
 *.d.ts
 tests/.env

--- a/japaFile.js
+++ b/japaFile.js
@@ -1,7 +1,0 @@
-require("ts-node").register();
-
-const { configure } = require("japa");
-
-configure({
-    files: ["tests/*.spec.js", "tests/*/**/*.spec.js"]
-});

--- a/japaFile.ts
+++ b/japaFile.ts
@@ -1,0 +1,9 @@
+import { configure, run } from "@japa/runner";
+import { assert } from "@japa/assert";
+
+configure({
+    plugins: [assert()],
+    files: ["tests/*.spec.ts", "tests/*/**/*.spec.ts"]
+});
+
+run();

--- a/japaFile.ts
+++ b/japaFile.ts
@@ -1,5 +1,7 @@
-import { configure, run } from "@japa/runner";
+import { configure, processCLIArgs, run } from "@japa/runner";
 import { assert } from "@japa/assert";
+
+processCLIArgs(process.argv.slice(2));
 
 configure({
     plugins: [assert()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jsonbank",
-    "version": "1.5.4",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "jsonbank",
-            "version": "1.5.4",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1413 +1,911 @@
 {
-  "name": "jsonbank",
-  "version": "1.5.4",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "jsonbank",
-      "version": "1.5.4",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.3.5",
-        "object-collection": "^3.0.1"
-      },
-      "devDependencies": {
-        "@types/is-ci": "^3.0.0",
-        "@types/node": "^18.11.5",
-        "@xpresser/env": "^2.0.10",
-        "is-ci": "^3.0.1",
-        "japa": "^4.0.0",
-        "nodemon": "^2.0.20",
-        "prettier": "^2.7.1",
-        "ts-node": "^10.9.1",
-        "ts-node-dev": "^2.0.0",
-        "typescript": "^5.0.4"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/is-ci": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.1.0"
-      }
-    },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.194",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "18.15.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/strip-bom": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/strip-json-comments": {
-      "version": "0.0.30",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/yargs": {
-      "version": "15.0.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@xpresser/env": {
-      "version": "2.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.0.1",
-        "dotenv-expand": "^8.0.3"
-      }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/acorn": {
-      "version": "8.8.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
-      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/chai": {
-      "version": "4.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "3.8.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/convert-hrtime": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "8.0.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dynamic-dedupe": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.15.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/japa": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chai": "^4.2.0",
-        "chalk": "^4.0.0",
-        "debug": "^4.1.1",
-        "fast-glob": "^3.2.2",
-        "is-ci": "^2.0.0",
-        "jest-diff": "^26.0.1",
-        "ms": "^2.1.2",
-        "retry": "^0.12.0",
-        "time-span": "^4.0.0"
-      }
-    },
-    "node_modules/japa/node_modules/ci-info": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/japa/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/japa/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/japa/node_modules/is-ci": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^2.0.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "26.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "2.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.0"
-      }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nodemon": {
-      "version": "2.0.22",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-collection": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/object-collection/-/object-collection-3.0.1.tgz",
-      "integrity": "sha512-PUxX+vkUjJ2k1CulqMtFFOQ5ywEkENL0kHjQJ83zGxQMvi0grj+iqKCiaDaOwfS+n39JQ7GpqveTbaJNxEDG3w==",
-      "dependencies": {
-        "@types/lodash": "^4.14.178",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.7",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
+    "name": "jsonbank",
+    "version": "1.5.4",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "jsonbank",
+            "version": "1.5.4",
+            "license": "MIT",
+            "dependencies": {
+                "axios": "^1.3.5",
+                "object-collection": "^3.0.1"
+            },
+            "devDependencies": {
+                "@japa/assert": "^4.2.0",
+                "@japa/runner": "^5.3.0",
+                "@types/is-ci": "^3.0.0",
+                "@types/node": "^18.11.5",
+                "@xpresser/env": "^2.0.10",
+                "is-ci": "^3.0.1",
+                "prettier": "^2.7.1",
+                "typescript": "^5.0.4"
+            }
         },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
+        "node_modules/@japa/assert": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@japa/assert/-/assert-4.2.0.tgz",
+            "integrity": "sha512-Krgrcee01BN1StlVwK5JQP6LL5t3DE3uFNbfFoDTfW7kQuHB0xh6yfaV0hrgcoiEjsqmm2OOsVWeju9aXK4vIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/macroable": "^1.1.0",
+                "@types/chai": "^5.2.3",
+                "assertion-error": "^2.0.1",
+                "chai": "^6.2.1"
+            },
+            "engines": {
+                "node": ">=18.16.0"
+            },
+            "peerDependencies": {
+                "@japa/runner": "^3.1.2 || ^4.0.0 || ^5.0.0"
+            }
         },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.11.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
+        "node_modules/@japa/assert/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
+        "node_modules/@japa/assert/node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "~7.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/time-span": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
+        "node_modules/@japa/core": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/@japa/core/-/core-10.4.0.tgz",
+            "integrity": "sha512-1zvKL29i7r/4jqTNBsw91hk1tp6wbqFXvyV2p+Og4axDRhIXjSAfauRvBL9QuB80bOa+pDIMQ5kCTaCplSm0Eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/hooks": "^7.3.0",
+                "@poppinss/macroable": "^1.1.0",
+                "@poppinss/string": "^1.7.1",
+                "async-retry": "^1.3.3",
+                "emittery": "^1.2.0",
+                "string-width": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=24.0.0"
+            }
         },
-        "@swc/wasm": {
-          "optional": true
+        "node_modules/@japa/errors-printer": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-4.1.4.tgz",
+            "integrity": "sha512-ogPT87QLaugKyPVcq+ZypcetVeJpXZN7RfVRlRDIrSHsHBw6ILCtNXghVxD9POjqxtUM7RON3sUkgZzLnVQA5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/colors": "^4.1.6",
+                "jest-diff": "^30.2.0",
+                "supports-color": "^10.2.2",
+                "youch": "^4.1.0-beta.13"
+            },
+            "engines": {
+                "node": ">=18.16.0"
+            }
+        },
+        "node_modules/@japa/errors-printer/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@japa/errors-printer/node_modules/jest-diff": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+            "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.4.0",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@japa/errors-printer/node_modules/pretty-format": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.4.1",
+                "ansi-styles": "^5.2.0",
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@japa/errors-printer/node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@japa/runner": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@japa/runner/-/runner-5.3.0.tgz",
+            "integrity": "sha512-WCnTd1q2EpbKKa96NzL16kVxJXVLRj1VqbswNAn17hYSuMlNKKhPGNbAosB32QZVFcoe9fv4Ebh1HtjyAT/viw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@japa/core": "^10.4.0",
+                "@japa/errors-printer": "^4.1.4",
+                "@poppinss/colors": "^4.1.6",
+                "@poppinss/hooks": "^7.3.0",
+                "@poppinss/string": "^1.7.1",
+                "@poppinss/utils": "^7.0.0-next.6",
+                "error-stack-parser-es": "^1.0.5",
+                "find-cache-directory": "^6.0.0",
+                "getopts": "^2.3.0",
+                "supports-color": "^10.2.2",
+                "timekeeper": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18.16.0"
+            }
+        },
+        "node_modules/@japa/runner/node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@jest/diff-sequences": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+            "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/get-type": {
+            "version": "30.1.0",
+            "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+            "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/schemas": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@poppinss/colors": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+            "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kleur": "^4.1.5"
+            }
+        },
+        "node_modules/@poppinss/dumper": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+            "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/colors": "^4.1.5",
+                "@sindresorhus/is": "^7.0.2",
+                "supports-color": "^10.0.0"
+            }
+        },
+        "node_modules/@poppinss/dumper/node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@poppinss/exception": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+            "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@poppinss/hooks": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@poppinss/hooks/-/hooks-7.3.0.tgz",
+            "integrity": "sha512-/H35z/bWqHg7085QOxWUDYMidx6Kl6b8kIyzIXlRYzWvsk1xm9hQOlXWdWEYch+Gmn8eL7tThx59MBj8BLxDrQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@poppinss/macroable": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@poppinss/macroable/-/macroable-1.1.2.tgz",
+            "integrity": "sha512-FAVBRzzWhYP5mA3lCwLH1A0fKBqq5anyjGet90Z81aRK5c/+LTGUE1zJhZrErjaenBSOOI9BVUs3WVmotneFQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@poppinss/object-builder": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@poppinss/object-builder/-/object-builder-1.1.0.tgz",
+            "integrity": "sha512-FOrOq52l7u8goR5yncX14+k+Ewi5djnrt1JwXeS/FvnwAPOiveFhiczCDuvXdssAwamtrV2hp5Rw9v+n2T7hQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.6.0"
+            }
+        },
+        "node_modules/@poppinss/string": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@poppinss/string/-/string-1.7.2.tgz",
+            "integrity": "sha512-A182GLDfi36iDCbhDrHB0xzrPM1fO3GHnhCDIdadf8C6eycgct4m7zusbLwEh6GPaj2Pz5BVos7XK16w7tZ7wQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/pluralize": "^0.0.33",
+                "case-anything": "^3.1.2",
+                "pluralize": "^8.0.0",
+                "slugify": "^1.6.9"
+            }
+        },
+        "node_modules/@poppinss/types": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@poppinss/types/-/types-1.2.1.tgz",
+            "integrity": "sha512-qUYnzl0m9HJTWsXtr8Xo7CwDx6wcjrvo14bOVbIMIlKJCzKrm3LX55dRTDr1/x4PpSvKVgmxvC6Ly2YiqXKOvQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@poppinss/utils": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.1.tgz",
+            "integrity": "sha512-mveSvLI2YPC114mK5HCuSYfUtjpClf1wHG1VCqZJCp4U2ypPhIt62Iku5urh0kPAFvnvCVHx2bXBSH14qMTOlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/exception": "^1.2.3",
+                "@poppinss/object-builder": "^1.1.0",
+                "@poppinss/string": "^1.7.1",
+                "@poppinss/types": "^1.2.1",
+                "flattie": "^1.1.1"
+            }
+        },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.34.49",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+            "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@speed-highlight/core": {
+            "version": "1.2.15",
+            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+            "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/chai/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/is-ci": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ci-info": "^3.1.0"
+            }
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.14.194",
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "18.15.11",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/pluralize": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
+            "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@xpresser/env": {
+            "version": "2.0.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dotenv": "^16.0.1",
+                "dotenv-expand": "^8.0.3"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/async-retry": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+            "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "retry": "0.13.1"
+            }
+        },
+        "node_modules/async-retry/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+            "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+            "dependencies": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/case-anything": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-3.1.2.tgz",
+            "integrity": "sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/has-flag": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "3.8.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/common-path-prefix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+            "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/cookie-es": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.0.3",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/dotenv-expand": {
+            "version": "8.0.3",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/emittery": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.2.1.tgz",
+            "integrity": "sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
+        "node_modules/error-stack-parser-es": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+            "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/find-cache-directory": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/find-cache-directory/-/find-cache-directory-6.0.0.tgz",
+            "integrity": "sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "common-path-prefix": "^3.0.0",
+                "pkg-dir": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flattie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+            "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.2",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/getopts": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+            "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-ci": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ci-info": "^3.2.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "license": "MIT"
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-collection": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/object-collection/-/object-collection-3.0.1.tgz",
+            "integrity": "sha512-PUxX+vkUjJ2k1CulqMtFFOQ5ywEkENL0kHjQJ83zGxQMvi0grj+iqKCiaDaOwfS+n39JQ7GpqveTbaJNxEDG3w==",
+            "dependencies": {
+                "@types/lodash": "^4.14.178",
+                "lodash": "^4.17.21"
+            }
+        },
+        "node_modules/pkg-dir": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
+            "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.8.7",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "license": "MIT"
+        },
+        "node_modules/react-is-18": {
+            "name": "react-is",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-is-19": {
+            "name": "react-is",
+            "version": "19.2.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+            "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/slugify": {
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/timekeeper": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.3.1.tgz",
+            "integrity": "sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/typescript": {
+            "version": "5.0.4",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/youch": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+            "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/colors": "^4.1.6",
+                "@poppinss/dumper": "^0.7.0",
+                "@speed-highlight/core": "^1.2.14",
+                "cookie-es": "^3.0.1",
+                "youch-core": "^0.3.3"
+            }
+        },
+        "node_modules/youch-core": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+            "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@poppinss/exception": "^1.2.2",
+                "error-stack-parser-es": "^1.0.5"
+            }
         }
-      }
-    },
-    "node_modules/ts-node-dev": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
-        "tsconfig": "^7.0.0"
-      },
-      "bin": {
-        "ts-node-dev": "lib/bin.js",
-        "tsnd": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "*",
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tsconfig": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     }
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonbank",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonbank",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -12,23 +12,21 @@
         "prepublishOnly": "npm run test && npm run build",
         "build": "npx tsc",
         "watch": "npx tsc --watch",
-        "test": "npm run build && node ./japaFile.js",
-        "test-dev": "npm run build && nodemon ./japaFile.js"
+        "test": "bun japaFile.ts",
+        "test-dev": "bun --watch japaFile.ts"
     },
     "dependencies": {
         "axios": "^1.3.5",
         "object-collection": "^3.0.1"
     },
     "devDependencies": {
+        "@japa/assert": "^4.2.0",
+        "@japa/runner": "^5.3.0",
         "@types/is-ci": "^3.0.0",
         "@types/node": "^18.11.5",
         "@xpresser/env": "^2.0.10",
         "is-ci": "^3.0.1",
-        "japa": "^4.0.0",
-        "nodemon": "^2.0.20",
         "prettier": "^2.7.1",
-        "ts-node": "^10.9.1",
-        "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.4"
     },
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "jsonbank",
-  "version": "1.5.3",
-  "description": "Official Jsonbank Node Package.",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "repository": "https://github.com/jsonbankio/jsonbank-js",
-  "author": "jsonbankio",
-  "license": "MIT",
-  "private": false,
-  "scripts": {
-    "prepublishOnly": "npm run test && npm run build",
-    "build": "npx tsc",
-    "watch": "npx tsc --watch",
-    "test": "node ./japaFile.js",
-    "test-dev": "nodemon ./japaFile.js"
-  },
-  "dependencies": {
-    "axios": "^1.3.5",
-    "object-collection": "^3.0.1"
-  },
-  "devDependencies": {
-    "@types/is-ci": "^3.0.0",
-    "@types/node": "^18.11.5",
-    "@xpresser/env": "^2.0.10",
-    "is-ci": "^3.0.1",
-    "japa": "^4.0.0",
-    "nodemon": "^2.0.20",
-    "prettier": "^2.7.1",
-    "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.4"
-  },
-  "keywords": [
-    "jsonbank",
-    "json",
-    "bank",
-    "api",
-    "node",
-    "typescript"
-  ]
+    "name": "jsonbank",
+    "version": "1.5.3",
+    "description": "Official Jsonbank Node Package.",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "repository": "https://github.com/jsonbankio/jsonbank-js",
+    "author": "jsonbankio",
+    "license": "MIT",
+    "private": false,
+    "scripts": {
+        "prepublishOnly": "npm run test && npm run build",
+        "build": "npx tsc",
+        "watch": "npx tsc --watch",
+        "test": "npm run build && node ./japaFile.js",
+        "test-dev": "npm run build && nodemon ./japaFile.js"
+    },
+    "dependencies": {
+        "axios": "^1.3.5",
+        "object-collection": "^3.0.1"
+    },
+    "devDependencies": {
+        "@types/is-ci": "^3.0.0",
+        "@types/node": "^18.11.5",
+        "@xpresser/env": "^2.0.10",
+        "is-ci": "^3.0.1",
+        "japa": "^4.0.0",
+        "nodemon": "^2.0.20",
+        "prettier": "^2.7.1",
+        "ts-node": "^10.9.1",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.0.4"
+    },
+    "keywords": [
+        "jsonbank",
+        "json",
+        "bank",
+        "api",
+        "node",
+        "typescript"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsonbank",
-    "version": "1.5.4",
+    "version": "1.6.0",
     "description": "Official Jsonbank Node Package.",
     "main": "index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsonbank",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "Official Jsonbank Node Package.",
     "main": "index.js",
     "types": "index.d.ts",

--- a/qh.ts
+++ b/qh.ts
@@ -1,0 +1,29 @@
+import {
+    $json,
+    jsb_queries,
+    jsb_query_filters,
+} from "./src/JsonBankQuery";
+
+const { find, slice, get,map } = jsb_query_filters();
+
+
+console.log(
+    decodeURIComponent(
+        jsb_queries([
+            get("countries"),
+            find($json({region: "Europe"})),
+        ])
+    )
+);
+
+console.log();
+console.log(
+    decodeURIComponent(
+        jsb_queries([
+            get("countries"),
+            map("name"),
+            slice(0, 3)
+        ])
+    )
+);
+

--- a/qh.ts
+++ b/qh.ts
@@ -9,21 +9,21 @@ const { find, slice, get,map } = jsb_query_filters();
 
 console.log(
     decodeURIComponent(
-        jsb_queries([
+        jsb_queries(
             get("countries"),
             find($json({region: "Europe"})),
-        ])
+        )
     )
 );
 
 console.log();
 console.log(
     decodeURIComponent(
-        jsb_queries([
+        jsb_queries(
             get("countries"),
             map("name"),
             slice(0, 3)
-        ])
+        )
     )
 );
 

--- a/src/JsonBank.ts
+++ b/src/JsonBank.ts
@@ -2,11 +2,11 @@ import axios, { AxiosInstance } from "axios";
 import {
     jsb_makeDocumentPath,
     jsb_makeFolderPath,
-    jsb_Query,
-    JSBQuery
+
 } from "./helpers";
 import Memory from "./memory";
 import { JSB_Body, JSB_Response, JsonBankConfig } from "./types";
+import { parse_jsb_query, JSBQuery } from "./JsonBankQuery";
 
 export class JSB_Error extends Error {
     code?: string;
@@ -227,7 +227,7 @@ class JsonBank {
     ) {
         if (!query) return {};
 
-        const [q, additionalQueries] = jsb_Query(query);
+        const [q, additionalQueries] = parse_jsb_query(query);
 
         if (!q) return {};
 

--- a/src/JsonBankQuery.ts
+++ b/src/JsonBankQuery.ts
@@ -1,8 +1,7 @@
 /**
  * Allowed Query modifiers
  */
-
-const modifiers = [
+export const modifiers = [
     // Array
     "chunk",
     "first",
@@ -19,13 +18,9 @@ const modifiers = [
     "get",
     "at",
     "has",
-    "hasIn",
     "keys",
     "values",
-    "valuesIn",
-    "keysIn",
     "omit",
-    "unset",
     "pick",
 
     // lang
@@ -53,23 +48,58 @@ export type Modifier = (typeof modifiers)[number];
 
 export type JSBVar = { json: string };
 export type JSBVarJson = { var: string };
-
+export type JSBArgs = string | string[] | JQVariable;
 export type JSBQuery = {
     apply: Modifier;
-    args?: string | string[] | JSBVar | JSBVarJson;
+    args?: JSBArgs;
     query?: Record<string, any>;
 };
+
+type JQArg = string | number | JQVariable;
+type JQVar = "var" | "json" | "raw" | "b64";
+
+function stringifyIfNotString(data: any): string | any {
+    if (typeof data !== "string") {
+        return JSON.stringify(data);
+    }
+
+    return data;
+}
+class JQVariable {
+    public key: string;
+    constructor(public type: JQVar, public data: JQArg | object, key?: string) {
+        if (!key) {
+            // set key to random 5 char string of alphabet characters
+            key = Array.from({ length: 5 }, () =>
+                String.fromCharCode(97 + Math.random() * 26)
+            ).join("");
+        }
+
+        this.type = type;
+        this.key = key;
+
+        if (type === "json" || type === "raw") {
+            this.data = stringifyIfNotString(data);
+        } else if (type === "b64") {
+            this.type = "json";
+            const encodedData = Buffer.from(stringifyIfNotString(data)).toString("base64");
+            this.data = `b64(${encodedData})`;
+        } else {
+            this.data = data;
+        }
+    }
+}
 
 /**
  * Convert JSBQuery to string
  * @param queries - JSBQuery
  * @example
- * const [query, additionalQueries] = jsbQuery({
+ * const [query, additionalQueries] = parse_jsb_query({
  *   apply: "mapPick",
  *   args: ["name", "iso3"],
  * })
  */
-export function jsb_Query(
+export function parse_jsb_query(
     queries: JSBQuery | JSBQuery[]
 ): [string, Record<string, any>] {
     let $queries: string[] = [];
@@ -86,12 +116,13 @@ export function jsb_Query(
             } else if (Array.isArray(q.args)) {
                 query += "-" + q.args.join("-");
             } else {
-                // args is a JSBVar
-                const args = q.args;
-                const $var = Object.keys(args)[0];
-                const key = Object.values(args)[0];
-
-                query += `-${$var}(${key})`;
+                if (typeof q.args === "object" && q.args instanceof JQVariable) {
+                    const arg = q.args;
+                    query += `-${arg.type}(${arg.key})`;
+                    additionalQueries[arg.key] = arg.data;
+                } else {
+                    throw new Error(`Argument must be string, array of strings or JQVariable`);
+                }
             }
         }
 
@@ -108,32 +139,82 @@ export function jsb_Query(
     return [$queries.join(","), additionalQueries];
 }
 
+
+export function $var(data: string, key?: string) {
+    return new JQVariable("var", data, key);
+}
+
+export function $json(data: object, key?: string) {
+    return new JQVariable("json", data, key);
+}
+
+export function $raw(data: string | object, key?: string) {
+    return new JQVariable("raw", data, key);
+}
+
+export function $b64(data: object, key?: string) {
+    return new JQVariable("b64", data, key);
+}
+
+/**
+ * Convert JSBQuery or a list of JSBQuery to a query string
+ * @param queries
+ */
+export function jsb_queries(queries: JSBQuery[]) {
+    let queryStr = "";
+    let queryObj: Record<string, any> = {};
+
+    for (const jsbQuery of queries) {
+        const [query, additionalQueries] = parse_jsb_query(jsbQuery);
+
+        if (queryStr) queryStr += ",";
+        queryStr += query;
+
+        for (const [key, value] of Object.entries(additionalQueries)) {
+            queryObj[key] = value;
+        }
+    }
+
+    let url = new URL("https://query.jsonbank.io/");
+    url.searchParams.set("query", queryStr);
+    for (const [key, value] of Object.entries(queryObj)) {
+        url.searchParams.set(key, value);
+    }
+
+    return url.searchParams.toString();
+}
+
 /**
  * Generate helper functions for query modifiers
  * @example
- * const {mapPick, size} = jsb_generateModifierHelpers();
+ * const {slice, size} = jsb_query_filters();
  *
  * const query = [
- *  mapPick(args, query),
+ *  slice(0, 2),
  *  size()
  * ]
  */
-export function jsb_generateModifierHelpers() {
-    const helpers: Record<
-        Modifier,
-        (args?: JSBQuery["args"], query?: JSBQuery["query"]) => JSBQuery
-    > = {} as any;
+export function jsb_query_filters() {
+    const helpers: Record<Modifier, (...args: JQArg[]) => JSBQuery> = {} as any;
 
     /**
      * Loop through and create a helper function for each modifier
      */
     for (const modifier of modifiers) {
-        helpers[modifier] = (args, query) => {
-            return {
-                apply: modifier,
-                args,
-                query
-            };
+        helpers[modifier] = (...args: JQArg[]) => {
+            let queryArgs: any;
+
+            if (
+                args.length === 1 &&
+                typeof args[0] === "object" &&
+                args[0] instanceof JQVariable
+            ) {
+                queryArgs = args[0];
+            } else {
+                queryArgs = args;
+            }
+
+            return { apply: modifier, args: queryArgs };
         };
     }
 

--- a/src/JsonBankQuery.ts
+++ b/src/JsonBankQuery.ts
@@ -45,9 +45,6 @@ export const modifiers = [
     "sum"
 ] as const;
 export type Modifier = (typeof modifiers)[number];
-
-export type JSBVar = { json: string };
-export type JSBVarJson = { var: string };
 export type JSBArgs = string | string[] | JQVariable;
 export type JSBQuery = {
     apply: Modifier;
@@ -55,8 +52,7 @@ export type JSBQuery = {
     query?: Record<string, any>;
 };
 
-type JQArg = string | number | JQVariable;
-type JQVar = "var" | "json" | "raw" | "b64";
+
 
 function stringifyIfNotString(data: any): string | any {
     if (typeof data !== "string") {
@@ -65,6 +61,9 @@ function stringifyIfNotString(data: any): string | any {
 
     return data;
 }
+export type JQArg = string | number | JQVariable;
+
+type JQVar = "var" | "json" | "raw" | "b64";
 class JQVariable {
     public key: string;
     constructor(public type: JQVar, public data: JQArg | object, key?: string) {
@@ -91,7 +90,7 @@ class JQVariable {
 }
 
 /**
- * Convert JSBQuery to string
+ * Parse JSBQuery to string and additional queries
  * @param queries - JSBQuery
  * @example
  * const [query, additionalQueries] = parse_jsb_query({
@@ -160,7 +159,7 @@ export function $b64(data: object, key?: string) {
  * Convert JSBQuery or a list of JSBQuery to a query string
  * @param queries
  */
-export function jsb_queries(queries: JSBQuery[]) {
+export function jsb_queries(...queries: JSBQuery[]) {
     let queryStr = "";
     let queryObj: Record<string, any> = {};
 

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,8 +1,8 @@
 import test from "japa";
-import { jsb_Query } from "../src/JsonBankQuery";
+import { $json, $var, parse_jsb_query } from "../src/JsonBankQuery";
 
 test("jsb_Query()", (assert) => {
-    const [query] = jsb_Query({
+    const [query] = parse_jsb_query({
         apply: "get",
         args: "name"
     });
@@ -10,8 +10,8 @@ test("jsb_Query()", (assert) => {
     assert.deepEqual(query, "get-name");
 });
 
-test("jsb_Query(): with array of  string Args", (assert) => {
-    const [query] = jsb_Query({
+test("jsb_Query(): with array of string Args", (assert) => {
+    const [query] = parse_jsb_query({
         apply: "mapPick",
         args: ["name", "phone"]
     });
@@ -19,11 +19,10 @@ test("jsb_Query(): with array of  string Args", (assert) => {
     assert.deepEqual(query, "mapPick-name-phone");
 });
 
-test("jsb_Query(): with va  r Args", (assert) => {
-    const [query, additionalQueries] = jsb_Query({
+test("jsb_Query(): with var Args", (assert) => {
+    const [query, additionalQueries] = parse_jsb_query({
         apply: "mapPick",
-        args: { var: "keys" },
-        query: { keys: "name-iso3" }
+        args: $var("name-iso3","keys"),
     });
 
     assert.equal(query, "mapPick-var(keys)");
@@ -31,12 +30,14 @@ test("jsb_Query(): with va  r Args", (assert) => {
 });
 
 test("jsb_Query(): with json Args", (assert) => {
-    const [query, additionalQueries] = jsb_Query({
+    const [query, additionalQueries] = parse_jsb_query({
         apply: "mapPick",
-        args: { json: "keys" },
-        query: { keys: ["name", "iso3"] }
+        args: $json(["name", "iso3"], "keys"),
     });
 
     assert.equal(query, "mapPick-json(keys)");
     assert.deepEqual(additionalQueries, { keys: ["name", "iso3"] });
 });
+
+
+// get-name -- get(name)

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -36,7 +36,7 @@ test("jsb_Query(): with json Args", (assert) => {
     });
 
     assert.equal(query, "mapPick-json(keys)");
-    assert.deepEqual(additionalQueries, { keys: ["name", "iso3"] });
+    assert.deepEqual(additionalQueries, { keys: JSON.stringify(["name", "iso3"]) });
 });
 
 

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,7 +1,8 @@
-import test from "japa";
+import { test } from "@japa/runner";
+import type { Assert } from "@japa/assert";
 import { $json, $var, parse_jsb_query } from "../src/JsonBankQuery";
 
-test("jsb_Query()", (assert) => {
+test("jsb_Query()", ({ assert }: { assert: Assert }) => {
     const [query] = parse_jsb_query({
         apply: "get",
         args: "name"
@@ -10,7 +11,7 @@ test("jsb_Query()", (assert) => {
     assert.deepEqual(query, "get-name");
 });
 
-test("jsb_Query(): with array of string Args", (assert) => {
+test("jsb_Query(): with array of string Args", ({ assert }: { assert: Assert }) => {
     const [query] = parse_jsb_query({
         apply: "mapPick",
         args: ["name", "phone"]
@@ -19,7 +20,7 @@ test("jsb_Query(): with array of string Args", (assert) => {
     assert.deepEqual(query, "mapPick-name-phone");
 });
 
-test("jsb_Query(): with var Args", (assert) => {
+test("jsb_Query(): with var Args", ({ assert }: { assert: Assert }) => {
     const [query, additionalQueries] = parse_jsb_query({
         apply: "mapPick",
         args: $var("name-iso3","keys"),
@@ -29,7 +30,7 @@ test("jsb_Query(): with var Args", (assert) => {
     assert.deepEqual(additionalQueries, { keys: "name-iso3" });
 });
 
-test("jsb_Query(): with json Args", (assert) => {
+test("jsb_Query(): with json Args", ({ assert }: { assert: Assert }) => {
     const [query, additionalQueries] = parse_jsb_query({
         apply: "mapPick",
         args: $json(["name", "iso3"], "keys"),

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -72,9 +72,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         const content = await jsb.getContent(testDoc.id);
         // test with .json extension
         const content2 = await jsb.getContent(testDoc.id + ".json");
-
         assert.deepEqual(content, TestFileContent);
-
         assert.deepEqual(content, content2);
     });
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,4 +1,5 @@
-import test from "japa";
+import { test } from "@japa/runner";
+import type { Assert } from "@japa/assert";
 import env from "./env";
 import JsonBankNode from "../src/JsonBankNode";
 import os from "os";
@@ -30,7 +31,7 @@ const NewDocumentExpectedKeys = [
 ];
 
 test.group("JsonBank: Not Authenticated", (group) => {
-    group.timeout(env.JSB_TIMEOUT);
+    group.each.timeout(env.JSB_TIMEOUT);
 
     let jsb: JsonBankNode;
     const testDoc = {
@@ -38,7 +39,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         path: "jsonbank/sdk-test/index"
     };
 
-    group.before(async () => {
+    group.setup(async () => {
         jsb = new JsonBankNode({ host: env.JSB_HOST });
 
         // Find id of a test document
@@ -59,15 +60,15 @@ test.group("JsonBank: Not Authenticated", (group) => {
         }
     });
 
-    test.failing("authenticate(): Should not be able to authenticate", async () => {
+    test("authenticate(): Should not be able to authenticate", async () => {
         await jsb.authenticate();
-    });
+    }).fails();
 
-    test("isAuthenticated(): Should not be authenticated", async (assert) => {
+    test("isAuthenticated(): Should not be authenticated", async ({ assert }: { assert: Assert }) => {
         await assert.isFalse(jsb.isAuthenticated());
     });
 
-    test("getContent(): Get public content by Id", async (assert) => {
+    test("getContent(): Get public content by Id", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getContent(testDoc.id);
         // test with .json extension
         const content2 = await jsb.getContent(testDoc.id + ".json");
@@ -77,7 +78,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         assert.deepEqual(content, content2);
     });
 
-    test("getContentAsString(): Get public content by Id", async (assert) => {
+    test("getContentAsString(): Get public content by Id", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getContentAsString(testDoc.id);
         // test with .json extension
         const content2 = await jsb.getContentAsString(testDoc.id + ".json");
@@ -87,7 +88,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         assert.deepEqual(content, content2);
     });
 
-    test("getContent(): Get public content by id with {jsbQuery}", async (assert) => {
+    test("getContent(): Get public content by id with {jsbQuery}", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getContent(testDoc.id, {
             apply: "pick",
             args: ["name"] /// only pick name
@@ -98,17 +99,17 @@ test.group("JsonBank: Not Authenticated", (group) => {
         });
     });
 
-    test("getDocumentMeta(): Get public content meta by ID", async (assert) => {
+    test("getDocumentMeta(): Get public content meta by ID", async ({ assert }: { assert: Assert }) => {
         const meta = await jsb.getDocumentMeta(testDoc.id);
         // test with .json extension
         const meta2 = await jsb.getDocumentMeta(testDoc.id + ".json");
 
-        assert.hasAllKeys(meta, MetaExpectedKeys);
+        assert.onlyProperties(meta, MetaExpectedKeys);
 
         assert.deepEqual(meta, meta2);
     });
 
-    test("getContent(): Get public content by path", async (assert) => {
+    test("getContent(): Get public content by path", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getContent("jsonbank/sdk-test/index");
         // test with .json extension
         const content2 = await jsb.getContent("jsonbank/sdk-test/index.json");
@@ -118,7 +119,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         assert.deepEqual(content, content2);
     });
 
-    test("getContent(): Get public content by path with {jsbQuery}", async (assert) => {
+    test("getContent(): Get public content by path with {jsbQuery}", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getContent("jsonbank/sdk-test/index", {
             apply: "pick",
             args: ["name"] /// only pick name
@@ -129,17 +130,17 @@ test.group("JsonBank: Not Authenticated", (group) => {
         });
     });
 
-    test("getDocumentMeta(): Get public content meta by path", async (assert) => {
+    test("getDocumentMeta(): Get public content meta by path", async ({ assert }: { assert: Assert }) => {
         const meta = await jsb.getDocumentMeta("jsonbank/sdk-test/index");
         // test with .json extension
         const meta2 = await jsb.getDocumentMeta("jsonbank/sdk-test/index.json");
 
-        assert.hasAllKeys(meta, MetaExpectedKeys);
+        assert.onlyProperties(meta, MetaExpectedKeys);
 
         assert.deepEqual(meta, meta2);
     });
 
-    test("getGithubContent(): Get content from github", async (assert) => {
+    test("getGithubContent(): Get content from github", async ({ assert }: { assert: Assert }) => {
         const pkg = await jsb.getGithubContent(
             "jsonbankio/jsonbank-js/package.json"
         );
@@ -149,7 +150,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
         assert.equal(pkg.author, "jsonbankio");
     });
 
-    test("getGithubContent(): Get content from github with jsbQuery", async (assert) => {
+    test("getGithubContent(): Get content from github with jsbQuery", async ({ assert }: { assert: Assert }) => {
         const pkg = await jsb.getGithubContent(
             "jsonbankio/jsonbank-js/package.json",
             { apply: "pick", args: ["name", "author"] }
@@ -164,7 +165,7 @@ test.group("JsonBank: Not Authenticated", (group) => {
 });
 
 test.group("JsonBank: Authenticated", (group) => {
-    group.timeout(env.JSB_TIMEOUT);
+    group.each.timeout(env.JSB_TIMEOUT);
 
     let jsb: JsonBankNode;
     const project = "sdk-test";
@@ -173,7 +174,7 @@ test.group("JsonBank: Authenticated", (group) => {
         path: `${project}/index`
     };
 
-    group.before(async () => {
+    group.setup(async () => {
         jsb = new JsonBankNode({
             host: env.JSB_HOST,
             keys: {
@@ -194,47 +195,47 @@ test.group("JsonBank: Authenticated", (group) => {
         testDoc.id = document.id;
     });
 
-    test("isAuthenticated()", async (assert) => {
+    test("isAuthenticated()", async ({ assert }: { assert: Assert }) => {
         assert.isTrue(jsb.isAuthenticated());
     });
 
-    test("getUsername():", async (assert) => {
+    test("getUsername():", async ({ assert }: { assert: Assert }) => {
         assert.equal(await jsb.getUsername(), "jsonbank");
     });
 
-    test("getOwnContent():", async (assert) => {
+    test("getOwnContent():", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getOwnContent(testDoc.id);
 
         assert.deepEqual(content, TestFileContent);
     });
 
-    test("getOwnContentAsString(): by path", async (assert) => {
+    test("getOwnContentAsString(): by path", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getOwnContentAsString(`${project}/index`);
         assert.deepEqual(content, JSON.stringify(TestFileContent));
     });
 
-    test("getOwnDocumentMeta():", async (assert) => {
+    test("getOwnDocumentMeta():", async ({ assert }: { assert: Assert }) => {
         const meta = await jsb.getOwnDocumentMeta(testDoc.id);
-        assert.hasAllKeys(meta, MetaExpectedKeys);
+        assert.onlyProperties(meta, MetaExpectedKeys);
     });
 
-    test("getOwnContent(): by path", async (assert) => {
+    test("getOwnContent(): by path", async ({ assert }: { assert: Assert }) => {
         const content = await jsb.getOwnContent(`${project}/index`);
         assert.deepEqual(content, TestFileContent);
     });
 
-    test("getOwnDocumentMeta(): by path", async (assert) => {
+    test("getOwnDocumentMeta(): by path", async ({ assert }: { assert: Assert }) => {
         const meta = await jsb.getOwnDocumentMeta(`${project}/index`);
-        assert.hasAllKeys(meta, MetaExpectedKeys);
+        assert.onlyProperties(meta, MetaExpectedKeys);
     });
 
-    test("hasOwnDocument()", async (assert) => {
+    test("hasOwnDocument()", async ({ assert }: { assert: Assert }) => {
         assert.isTrue(await jsb.hasOwnDocument(testDoc.id));
         // fail
         assert.isFalse(await jsb.hasOwnDocument("not-existing-id"));
     });
 
-    test("updateContent():", async (assert) => {
+    test("updateContent():", async ({ assert }: { assert: Assert }) => {
         const newContent = {
             ...TestFileContent,
             updatedAt: new Date().toISOString()
@@ -257,7 +258,7 @@ test.group("JsonBank: Authenticated", (group) => {
         await jsb.updateOwnDocument(`${project}/index`, TestFileContent);
     });
 
-    test("createFolder():", async (assert) => {
+    test("createFolder():", async ({ assert }: { assert: Assert }) => {
         try {
             const folder = await jsb.createFolder({
                 name: "folder",
@@ -265,7 +266,7 @@ test.group("JsonBank: Authenticated", (group) => {
             });
 
             assert.isObject(folder);
-            assert.hasAllKeys(folder, ["id", "name", "path", "project"]);
+            assert.onlyProperties(folder, ["id", "name", "path", "project"]);
 
             // check folder name matches
             assert.equal(folder.name, "folder");
@@ -276,7 +277,7 @@ test.group("JsonBank: Authenticated", (group) => {
         }
     });
 
-    test("createDocument():", async (assert) => {
+    test("createDocument():", async ({ assert }: { assert: Assert }) => {
         await jsb.deleteDocument(`${project}/folder/new_doc`);
 
         const doc = await jsb.createDocument({
@@ -290,14 +291,14 @@ test.group("JsonBank: Authenticated", (group) => {
         });
 
         assert.isObject(doc);
-        assert.hasAllKeys(doc, NewDocumentExpectedKeys);
+        assert.onlyProperties(doc, NewDocumentExpectedKeys);
         // test project name
         assert.equal(doc.project, project);
 
         await jsb.deleteDocument(`${project}/folder/new_doc`);
     });
 
-    test("uploadDocument():", async (assert) => {
+    test("uploadDocument():", async ({ assert }: { assert: Assert }) => {
         // delete file if exists
         await jsb.deleteDocument(`${project}/folder/upload`);
 
@@ -309,16 +310,16 @@ test.group("JsonBank: Authenticated", (group) => {
         });
 
         assert.isObject(doc);
-        assert.hasAllKeys(doc, NewDocumentExpectedKeys);
+        assert.onlyProperties(doc, NewDocumentExpectedKeys);
         // test project name
         assert.equal(doc.project, project);
     });
 
-    test("getFolder", async (assert) => {
+    test("getFolder", async ({ assert }: { assert: Assert }) => {
         const folder = await jsb.getFolder(`${project}/folder`);
 
         assert.isObject(folder);
-        assert.hasAllKeys(folder, [
+        assert.onlyProperties(folder, [
             "id",
             "name",
             "path",
@@ -336,11 +337,11 @@ test.group("JsonBank: Authenticated", (group) => {
         assert.deepEqual(folder, folder2);
     });
 
-    test("getFolder with stats", async (assert) => {
+    test("getFolder with stats", async ({ assert }: { assert: Assert }) => {
         const folder = await jsb.getFolderWithStats(`${project}/folder`);
 
         assert.isObject(folder);
-        assert.hasAllKeys(folder, [
+        assert.onlyProperties(folder, [
             "id",
             "name",
             "path",
@@ -359,14 +360,14 @@ test.group("JsonBank: Authenticated", (group) => {
         assert.deepEqual(folder, folder2);
     });
 
-    test("createFolderIfNotExists", async (assert) => {
+    test("createFolderIfNotExists", async ({ assert }: { assert: Assert }) => {
         const folder = await jsb.createFolderIfNotExists({
             name: "folder",
             project
         });
 
         assert.isObject(folder);
-        assert.hasAllKeys(folder, [
+        assert.onlyProperties(folder, [
             "id",
             "name",
             "path",

--- a/tests/jsb-query.spec.ts
+++ b/tests/jsb-query.spec.ts
@@ -1,0 +1,66 @@
+import { test } from "@japa/runner";
+import type { Assert } from "@japa/assert";
+import JsonBankNode from "../src/JsonBankNode";
+import env from "./env";
+import { $json, $raw, $var, jsb_query_filters } from "../src/JsonBankQuery";
+
+test.group("Jsb Query", (group) => {
+    const jsb = new JsonBankNode({ host: env.JSB_HOST });
+    const { get, map, mapPick, slice, filter, at } = jsb_query_filters();
+
+    test("getContent()", async ({ assert }: { assert: Assert }) => {
+        const content = await jsb.getContent("jsonbank/tests/countries.json", [
+            get("countries"),
+            map("name"),
+            slice(0, 3)
+        ]);
+
+        assert.deepEqual(content, ["Afghanistan", "Albania", "Algeria"]);
+    });
+
+    test("var()", async ({ assert }: { assert: Assert }) => {
+        const content = await jsb.getContent("jsonbank/tests/countries.json", [
+            get("countries"),
+            mapPick($var("name,capital"))
+        ]);
+
+        assert.isArray(content);
+        assert.isAbove(content.length, 0);
+        assert.deepEqual(content[0], {
+            name: "Afghanistan",
+            capital: "Kabul"
+        });
+    });
+
+    test("raw()", async ({ assert }: { assert: Assert }) => {
+        const content = await jsb.getContent("jsonbank/tests/countries.json", [
+            at($raw("countries[4].name")),
+        ]);
+
+        assert.isArray(content);
+        assert.deepEqual(content, ["Australia"]);
+    });
+
+    test("json()", async ({ assert }: { assert: Assert }) => {
+        const content = await jsb.getContent("jsonbank/tests/countries.json", [
+            get("countries"),
+
+            filter($json({ currency: "EUR" })),
+            map("name")
+        ]);
+
+        assert.deepEqual(content, [
+            "Austria",
+            "Belgium",
+            "Finland",
+            "France",
+            "Germany",
+            "Greece",
+            "Ireland",
+            "Italy",
+            "Netherlands",
+            "Portugal",
+            "Spain"
+        ]);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,8 +51,16 @@
 
     /* Module Resolution Options */
      "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": ".",
+    "paths": {
+      "@japa/core": ["./node_modules/@japa/core/build/index"],
+      "@japa/core/*": ["./node_modules/@japa/core/build/*"],
+      "@japa/runner/core": ["./node_modules/@japa/runner/build/modules/core/main"],
+      "@japa/runner/types": ["./node_modules/@japa/runner/build/src/types"],
+      "@japa/assert": ["./node_modules/@japa/assert/build/index"],
+      "@japa/assert/*": ["./node_modules/@japa/assert/build/*"]
+    },
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
This pull request introduces significant updates to modernize the development workflow, testing setup, and query-building utilities for the project. The main changes include migrating the CI workflow and test runner from Node.js/Japa to Bun/@japa/runner, refactoring and enhancing the query builder API, and updating tests and dependencies to reflect these improvements.

**Development workflow and tooling updates:**

* Migrated CI from Node.js to Bun, updating the GitHub Actions workflow (`.github/workflows/build.yml`) to use Bun for installing dependencies and running tests, and switched the default branch from `master` to `main`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-L10) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R20)
* Replaced the legacy Japa test runner with the modern `@japa/runner` and `@japa/assert` packages, updating all test files and scripts to TypeScript and Bun. Removed obsolete test runner files and dependencies, and updated test scripts in `package.json` accordingly. [[1]](diffhunk://#diff-3d0a445527f75a3c146222a8b2915cfc9c385c0f31e39d1bb89f57c11a8b73d4L1-L7) [[2]](diffhunk://#diff-f60158a4c79b8fb1ce8d0605255b530c7b9f51fb673719f260026f7651b9d674R1-R11) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-L31) [[4]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL1-R2) [[5]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL33-R42) [[6]](diffhunk://#diff-0c140153bb2ad1109475fbdf63e0dc3531834346bc06be28a67c5b8ded633bc1L1-R44)

**Query builder and API enhancements:**

* Refactored and renamed the query builder API: replaced `jsb_Query` with `parse_jsb_query`, introduced a new `JQVariable` class and utility functions (`$var`, `$json`, `$raw`, `$b64`) for more flexible query argument handling, and improved type safety and serialization. [[1]](diffhunk://#diff-f0795baba58835f9e8ccfcc9d3b4f7a5f29888d88bd39ba3e6ca389febd9d968L4-R4) [[2]](diffhunk://#diff-f0795baba58835f9e8ccfcc9d3b4f7a5f29888d88bd39ba3e6ca389febd9d968L53-R101) [[3]](diffhunk://#diff-f0795baba58835f9e8ccfcc9d3b4f7a5f29888d88bd39ba3e6ca389febd9d968L89-R124) [[4]](diffhunk://#diff-f0795baba58835f9e8ccfcc9d3b4f7a5f29888d88bd39ba3e6ca389febd9d968R141-R216)
* Added `jsb_queries` and `jsb_query_filters` helpers to simplify query construction and chaining, enabling more expressive and composable query expressions. [[1]](diffhunk://#diff-f0795baba58835f9e8ccfcc9d3b4f7a5f29888d88bd39ba3e6ca389febd9d968R141-R216) [[2]](diffhunk://#diff-cdd4fd5a1e1e31cfb47a05cf7cd4b434f928a3b822e4236122ac6a98b44ebca7R1-R29)
* Updated `JsonBank` class to use the new query parsing function, ensuring compatibility with the refactored query API. [[1]](diffhunk://#diff-4a24d9db0f904241bddd79aceae72c702c8298a63d6b6e0cffca4f6f7b156327L5-R9) [[2]](diffhunk://#diff-4a24d9db0f904241bddd79aceae72c702c8298a63d6b6e0cffca4f6f7b156327L230-R230)

**Testing improvements:**

* Migrated all tests to TypeScript and the new Japa runner, improving assertion clarity and updating test group and assertion syntax for better reliability and maintainability. [[1]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL62-R71) [[2]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL80-R81) [[3]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL90-R91) [[4]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL101-R112) [[5]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL121-R122) [[6]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL132-R143) [[7]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL152-R153) [[8]](diffhunk://#diff-20b1de351813b58108f67a31e630620abeaba5d9a76e601183f4311a34390b9cL167-R168) [[9]](diffhunk://#diff-0c140153bb2ad1109475fbdf63e0dc3531834346bc06be28a67c5b8ded633bc1L1-R44)
* Enhanced test coverage for the query builder, adding cases for new argument types and serialization logic.

**Dependency and version updates:**

* Bumped package version to `1.6.0` and updated dependencies in `package.json` to reflect the new test runner and query builder utilities. Removed unused packages related to the old test setup. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-L31)

**New example and utility files:**

* Added `qh.ts` as an example or utility for constructing and printing queries using the new query builder API.